### PR TITLE
Switch apache2ctl to apachectl for SUSE distributions

### DIFF
--- a/changelog/14.fixed.md
+++ b/changelog/14.fixed.md
@@ -1,0 +1,1 @@
+Switch apache2ctl to apachectl for SUSE distributions

--- a/src/saltext/apache/modules/apache.py
+++ b/src/saltext/apache/modules/apache.py
@@ -44,7 +44,7 @@ def _detect_os():
     os_family = __grains__["os_family"]
     if os_family == "RedHat":
         return "apachectl"
-    if os_family in ("Debian", "Suse"):
+    if os_family == "Debian":
         return "apache2ctl"
     return "apachectl"
 

--- a/src/saltext/apache/modules/suse_apache.py
+++ b/src/saltext/apache/modules/suse_apache.py
@@ -19,7 +19,7 @@ def __virtual__():
     """
     Only load the module if apache is installed.
     """
-    if salt.utils.path.which("apache2ctl") and __grains__["os_family"] == "Suse":
+    if salt.utils.path.which("apachectl") and __grains__["os_family"] == "Suse":
         return __virtualname__
     return (False, "apache execution module not loaded: apache not installed.")
 

--- a/tests/unit/modules/test_suse_apache.py
+++ b/tests/unit/modules/test_suse_apache.py
@@ -1,0 +1,73 @@
+"""
+:codeauthor: Georg Pfuetzenreuter <mail+salt@georg-pfuetzenreuter.net>
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from saltext.apache.modules import suse_apache
+
+sample_a2enmod_l_output = "actions alias auth_basic authn_core authn_file authz_host authz_groupfile authz_core authz_user autoindex cgi dir env expires include log_config mime negotiation setenvif ssl socache_shmcb userdir reqtimeout apparmor proxy proxy_fcgi remoteip rewrite"
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {suse_apache: {}}
+
+
+def test_check_mod_enabled():
+    """
+    Test if mod_enabled() finds if specified modules are enabled.
+    """
+
+    with patch.dict(
+        suse_apache.__salt__,
+        {"cmd.run": MagicMock(return_value=sample_a2enmod_l_output)},
+    ):
+        assert suse_apache.check_mod_enabled("rewrite")
+
+
+def test_check_mod_enabled_not():
+    """
+    Test if mod_enabled() finds if specified modules are not enabled.
+    """
+
+    with patch.dict(
+        suse_apache.__salt__,
+        {"cmd.run": MagicMock(return_value=sample_a2enmod_l_output)},
+    ):
+        assert not suse_apache.check_mod_enabled("status")
+
+
+def test_a2enmod():
+    """
+    Test if a2enmod() enables specified modules.
+    """
+
+    with patch.dict(
+        suse_apache.__salt__,
+        {"cmd.retcode": MagicMock(return_value=0)},
+    ):
+        assert suse_apache.a2enmod("status") == {
+            "Name": "Apache2 Enable Mod",
+            "Mod": "status",
+            "Status": "Mod status enabled",
+        }
+
+
+def test_a2dismod():
+    """
+    Test if a2dismod() disables specified modules.
+    """
+
+    with patch.dict(
+        suse_apache.__salt__,
+        {"cmd.retcode": MagicMock(return_value=0)},
+    ):
+        assert suse_apache.a2dismod("status") == {
+            "Name": "Apache2 Disable Mod",
+            "Mod": "status",
+            "Status": "Mod status disabled",
+        }


### PR DESCRIPTION
With openSUSE Leap 16,  we no longer ship the /usr/sbin/apache2ctl -> /usr/sbin/apachectl symlink. As /usr/sbin/apachectl is already present in older distributions, update the references instead of introducing additional logic.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/salt-extensions/saltext-apache/issues/13

### Previous Behavior

`apache.*` module calls would not work on openSUSE Leap 16.

### New Behavior

They work again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or new features require tests.**
<!-- Please review the [salt-extensions](https://salt-extensions.github.io/salt-extension-copier/topics/testing/writing.html) and [Salt test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests for your changes. -->
- [ ] Docs
- [x] Changelog - https://salt-extensions.github.io/salt-extension-copier/topics/documenting/changelog.html#procedure
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
